### PR TITLE
🧪 add test-utils package

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ This project is a monorepo that includes the following packages.
 | ------------------------------------------------------------------------------ | --------------------- | --------------------- |
 | [@http-ext/core](https://www.npmjs.com/package/@http-ext/core)                 | Core module           | Extensibility         |
 | [@http-ext/angular](https://www.npmjs.com/package/@http-ext/angular)           | Angular module        | Angular compatibility |
-| [@http-ext/plugin-cache](https://www.npmjs.com/package/@http-ext/plugin-cache) | Cache plugin          | Fast and reactive UI  |
+| [@http-ext/test-utils](https://www.npmjs.com/package/@http-ext/test-utils)     | Testing module        | Testability           |
+| [@http-ext/plugin-cache](https://www.npmjs.com/package/@http-ext/plugin-cache) | Cache plugin          | Performance           |
 | @http-ext/plugin-retry                                                         | Retry back-off plugin | Resilience            |
 | @http-ext/plugin-authentication                                                | Authentication plugin | Security              |
 
@@ -44,14 +45,14 @@ This library follows the semantic versioning specification. Changelog is availab
       <a href="https://github.com/yjaaidi" style="color: white">
         <img src="https://github.com/yjaaidi.png?s=150" width="150"/>
       </a>
-      <p style="margin: 0;"><strong>Younes Jaaidi</strong></p>
+      <p><strong>Younes Jaaidi</strong></p>
       <p><strong>twitter: </strong><a href="https://twitter.com/yjaaidi">@yjaaidi</a></p>
     </td>
     <td align="center">
       <a href="https://github.com/Edouardbozon" style="color: white">
         <img src="https://github.com/Edouardbozon.png?s=150" width="150"/>
       </a>
-      <p style="margin: 0;"><strong>Edouard Bozon</strong></p>
+      <p><strong>Edouard Bozon</strong></p>
       <p><strong>twitter: </strong><a href="https://twitter.com/edouardbozon">@edouardbozon</a></p>
     </td>
   </tr>

--- a/angular.json
+++ b/angular.json
@@ -221,6 +221,33 @@
         }
       },
       "schematics": {}
+    },
+    "test-utils": {
+      "projectType": "library",
+      "root": "libs/test-utils",
+      "sourceRoot": "libs/test-utils/src",
+      "prefix": "http-ext",
+      "architect": {
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": [
+              "libs/test-utils/tsconfig.lib.json",
+              "libs/test-utils/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/test-utils/**"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/test-utils/jest.config.js",
+            "tsConfig": "libs/test-utils/tsconfig.spec.json",
+            "setupFile": "libs/test-utils/src/test-setup.ts"
+          }
+        }
+      },
+      "schematics": {}
     }
   },
   "cli": {

--- a/libs/angular/src/lib/http-ext.module.spec.ts
+++ b/libs/angular/src/lib/http-ext.module.spec.ts
@@ -4,7 +4,7 @@ import {
   HttpTestingController
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { createSpyPlugin } from '@http-ext/core/src/lib/http-ext.spec';
+import { createSpyPlugin } from '@http-ext/test-utils';
 
 import { HttpExtModule } from './http-ext.module';
 

--- a/libs/core/src/lib/http-ext.spec.ts
+++ b/libs/core/src/lib/http-ext.spec.ts
@@ -1,19 +1,9 @@
+import { createSpyPlugin } from '@http-ext/test-utils';
 import { of } from 'rxjs';
 
 import { HttpExt } from './http-ext';
-import { createRequest, HttpExtRequest } from './request';
+import { createRequest } from './request';
 import { createResponse } from './response';
-
-/* A plugin handle that just calls through the next plugin.*/
-export function createSpyPlugin(
-  condition: (request: HttpExtRequest) => boolean = (request: HttpExtRequest) =>
-    true
-) {
-  return {
-    condition: jest.fn(({ request }) => condition(request)),
-    handle: jest.fn(({ request, next }) => next({ request }))
-  };
-}
 
 describe('HttpExt', () => {
   it('should handle multiple plugins', () => {

--- a/libs/test-utils/README.md
+++ b/libs/test-utils/README.md
@@ -1,0 +1,7 @@
+# test-utils
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test test-utils` to execute the unit tests.

--- a/libs/test-utils/jest.config.js
+++ b/libs/test-utils/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'test-utils',
+  preset: '../../jest.config.js',
+  coverageDirectory: '../../coverage/libs/test-utils',
+  snapshotSerializers: [
+    'jest-preset-angular/AngularSnapshotSerializer.js',
+    'jest-preset-angular/HTMLCommentSerializer.js'
+  ]
+};

--- a/libs/test-utils/src/index.ts
+++ b/libs/test-utils/src/index.ts
@@ -1,0 +1,1 @@
+export { createSpyPlugin } from './lib/create-spy-plugin';

--- a/libs/test-utils/src/lib/create-spy-plugin.ts
+++ b/libs/test-utils/src/lib/create-spy-plugin.ts
@@ -1,0 +1,9 @@
+/* A plugin handle that just calls through the next plugin.*/
+export function createSpyPlugin(
+  condition: (request: any) => boolean = (request: any) => true
+) {
+  return {
+    condition: jest.fn(({ request }) => condition(request)),
+    handle: jest.fn(({ request, next }) => next({ request }))
+  };
+}

--- a/libs/test-utils/src/test-setup.ts
+++ b/libs/test-utils/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular';

--- a/libs/test-utils/tsconfig.json
+++ b/libs/test-utils/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/libs/test-utils/tsconfig.lib.json
+++ b/libs/test-utils/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts"]
+}

--- a/libs/test-utils/tsconfig.spec.json
+++ b/libs/test-utils/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/test-utils/tslint.json
+++ b/libs/test-utils/tslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tslint.json",
+  "rules": {
+    "directive-selector": [true, "attribute", "httpExt", "camelCase"],
+    "component-selector": [true, "element", "http-ext", "kebab-case"]
+  }
+}

--- a/nx.json
+++ b/nx.json
@@ -22,6 +22,9 @@
     },
     "angular": {
       "tags": []
+    },
+    "test-utils": {
+      "tags": []
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "paths": {
       "@http-ext/core": ["libs/core/src/index.ts"],
       "@http-ext/plugin-cache": ["libs/plugin-cache/src/index.ts"],
-      "@http-ext/angular": ["libs/angular/src/index.ts"]
+      "@http-ext/angular": ["libs/angular/src/index.ts"],
+      "@http-ext/test-utils": ["libs/test-utils/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
This is an attempt to fix module boundaries rule error from develop using a shared `test-utils` package. This approach comes with a problem. We can't use `core` exported things like `HttpExtRequest` type in `test-utils` and then use `test-utils` in `core` because it throws a circular dependency error.