### PR TITLE
fix(plugin-auth): 🐞 fix token nullish stream value

### DIFF
--- a/libs/plugin-auth/src/lib/auth-handler.spec.ts
+++ b/libs/plugin-auth/src/lib/auth-handler.spec.ts
@@ -8,6 +8,10 @@ import { AuthHandler } from './auth-handler';
 
 describe('AuthPlugin', () => {
   it('should add bearer token to each request', async () => {
+    /**
+     * The first `undefined` value ensure that the Authorization header
+     * isn't set with a nullish value and leads in a "Bearer undefined".
+     */
     const token$ = of(undefined, 'TOKEN');
 
     const pluginTester = createPluginTester({

--- a/libs/plugin-auth/src/lib/auth-handler.spec.ts
+++ b/libs/plugin-auth/src/lib/auth-handler.spec.ts
@@ -8,7 +8,7 @@ import { AuthHandler } from './auth-handler';
 
 describe('AuthPlugin', () => {
   it('should add bearer token to each request', async () => {
-    const token$ = of('TOKEN');
+    const token$ = of(undefined, 'TOKEN');
 
     const pluginTester = createPluginTester({
       handler: new AuthHandler({ token: token$ })

--- a/libs/plugin-auth/src/lib/auth-handler.ts
+++ b/libs/plugin-auth/src/lib/auth-handler.ts
@@ -1,6 +1,6 @@
 import { PluginHandler, PluginHandlerArgs } from '@http-ext/core';
 import { defer, Observable, throwError } from 'rxjs';
-import { catchError, first, map, switchMap } from 'rxjs/operators';
+import { catchError, first, map, switchMap, filter } from 'rxjs/operators';
 
 import { OnUnauthorized } from './on-unauthorized';
 import { setHeader } from './set-header';
@@ -22,6 +22,7 @@ export class AuthHandler implements PluginHandler {
   handle({ request: originalRequest, next }: PluginHandlerArgs) {
     return defer(() => {
       return this._token$.pipe(
+        filter(token => token != null),
         first(),
         map(token =>
           setHeader({


### PR DESCRIPTION
Fix the case when a token stream is initialized with `undefined` and leads in a `Bearer undefined` Authorization header. 